### PR TITLE
Added some more keywords mentioned in Dockerfile reference

### DIFF
--- a/docker.lang
+++ b/docker.lang
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Authors: Jasper van den Bosch <jasperb@uw.edu>
+ Authors: Jasper van den Bosch <jasperb@uw.edu>, Thomas F. Duellmann <duelle@autistici.org>
  Copyright (C) 2007 Nobody
  
  This library is free software; you can redistribute it and/or
@@ -43,6 +43,9 @@
             <keyword>VOLUME</keyword>
             <keyword>USER</keyword>
             <keyword>WORKDIR</keyword>
+            <keyword>LABEL</keyword>
+            <keyword>COPY</keyword>
+            <keyword>ONBUILD</keyword>
         </context>
         <context id="comment" end-at-line-end="true" style-ref="docker-comment">
           <start>#</start>

--- a/docker.lang
+++ b/docker.lang
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Authors: Jasper van den Bosch <jasperb@uw.edu>, Thomas F. Duellmann <duelle@autistici.org>
+ Authors: Jasper van den Bosch <jasperb@uw.edu>, Thomas F. Duellmann <t.duellmann@gmx.de>
  Copyright (C) 2007 Nobody
  
  This library is free software; you can redistribute it and/or
@@ -35,17 +35,19 @@
             <keyword>FROM</keyword>
             <keyword>MAINTAINER</keyword>
             <keyword>RUN</keyword>
-            <keyword>ADD</keyword>
             <keyword>CMD</keyword>
-            <keyword>ENTRYPOINT</keyword>
+            <keyword>LABEL</keyword>
             <keyword>EXPOSE</keyword>
             <keyword>ENV</keyword>
+            <keyword>ADD</keyword>
+            <keyword>COPY</keyword>
+            <keyword>ENTRYPOINT</keyword>
             <keyword>VOLUME</keyword>
             <keyword>USER</keyword>
             <keyword>WORKDIR</keyword>
-            <keyword>LABEL</keyword>
-            <keyword>COPY</keyword>
+            <keyword>ARG</keyword>
             <keyword>ONBUILD</keyword>
+            <keyword>STOPSIGNAL</keyword>
         </context>
         <context id="comment" end-at-line-end="true" style-ref="docker-comment">
           <start>#</start>


### PR DESCRIPTION
When I saw the missing highlights for some keywords in a Dockerfile I added the ones that are mentioned on the Dockerfile reference page: https://docs.docker.com/reference/builder/